### PR TITLE
refactor: centralize nonPatientNameFields constant

### DIFF
--- a/src/utils/nameFieldUtils.ts
+++ b/src/utils/nameFieldUtils.ts
@@ -1,18 +1,4 @@
-
-// List of keys that should be excluded from name fields
-export const nonPatientNameFields = [
-  "balozi_first_name", "\"balozi_first_name\"",
-  "balozi_middle_name", "\"balozi_middle_name\"", 
-  "balozi_last_name", "\"balozi_last_name\"",
-  "oldest_member_first_name", "\"oldest_member_first_name\"",
-  "oldest_member_middle_name", "\"oldest_member_middle_name\"",
-  "oldest_member_last_name", "\"oldest_member_last_name\"",
-  "cellLeaderFirstName", "cellLeaderMiddleName", "cellLeaderLastName",
-  "oldestHouseholdMemberFirstName", "oldestHouseholdMemberMiddleName", "oldestHouseholdMemberLastName",
-  "Ten Cell Leader First Name", "\"Ten Cell Leader First Name\"",
-  "Ten Cell Leader Middle Name", "\"Ten Cell Leader Middle Name\"",
-  "Ten Cell Leader Last Name", "\"Ten Cell Leader Last Name\""
-];
+import { nonPatientNameFields } from './recordConstants';
 
 /**
  * Enhanced helper to get name fields correctly with improved priority and consistency

--- a/src/utils/recordConstants.ts
+++ b/src/utils/recordConstants.ts
@@ -13,6 +13,17 @@ export const visitByOptions = [
 
 // Add missing export
 export const nonPatientNameFields = [
-  'id', 'patientId', 'birthDate', 'sex', 'address', 'phoneNumber', 
-  'email', 'village', 'subVillage', 'district', 'identifiers'
+  'id', 'patientId', 'birthDate', 'sex', 'address', 'phoneNumber',
+  'email', 'village', 'subVillage', 'district', 'identifiers',
+  'balozi_first_name', '"balozi_first_name"',
+  'balozi_middle_name', '"balozi_middle_name"',
+  'balozi_last_name', '"balozi_last_name"',
+  'oldest_member_first_name', '"oldest_member_first_name"',
+  'oldest_member_middle_name', '"oldest_member_middle_name"',
+  'oldest_member_last_name', '"oldest_member_last_name"',
+  'cellLeaderFirstName', 'cellLeaderMiddleName', 'cellLeaderLastName',
+  'oldestHouseholdMemberFirstName', 'oldestHouseholdMemberMiddleName', 'oldestHouseholdMemberLastName',
+  'Ten Cell Leader First Name', '"Ten Cell Leader First Name"',
+  'Ten Cell Leader Middle Name', '"Ten Cell Leader Middle Name"',
+  'Ten Cell Leader Last Name', '"Ten Cell Leader Last Name"'
 ];


### PR DESCRIPTION
## Summary
- centralize `nonPatientNameFields` definition in `recordConstants.ts`
- import shared constant in `nameFieldUtils.ts`

## Testing
- `npm run lint` *(fails: Unexpected any, prefer-const, no-require-imports)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689afa05eaa0832b9eb281c2414fc4ef