### PR TITLE
Load Supabase credentials from environment variables

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+VITE_SUPABASE_URL=https://your-project.supabase.co
+VITE_SUPABASE_KEY=your-anon-key

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ node_modules
 dist
 dist-ssr
 *.local
+.env
 
 # Editor directories and files
 .vscode/*

--- a/README.md
+++ b/README.md
@@ -36,6 +36,13 @@ npm i
 npm run dev
 ```
 
+## Environment Variables
+
+Create a `.env` file based on the provided `.env.example` and supply the following variables:
+
+- `VITE_SUPABASE_URL` – your Supabase project URL.
+- `VITE_SUPABASE_KEY` – your Supabase anonymous API key.
+
 **Edit a file directly in GitHub**
 
 - Navigate to the desired file(s).

--- a/src/integrations/supabase/client.ts
+++ b/src/integrations/supabase/client.ts
@@ -2,10 +2,10 @@
 import { createClient } from '@supabase/supabase-js';
 import type { Database } from './types';
 
-const SUPABASE_URL = "https://opwsrkvaqdxymqlhbhpl.supabase.co";
-const SUPABASE_PUBLISHABLE_KEY = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Im9wd3Nya3ZhcWR4eW1xbGhiaHBsIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NDE3Njg2ODEsImV4cCI6MjA1NzM0NDY4MX0.GmqPCvh-ePsPk3ICLKFBQCEglx_S3TMX7ASfn-rbJ8c";
+const SUPABASE_URL = import.meta.env.VITE_SUPABASE_URL!;
+const SUPABASE_KEY = import.meta.env.VITE_SUPABASE_KEY!;
 
 // Import the supabase client like this:
 // import { supabase } from "@/integrations/supabase/client";
 
-export const supabase = createClient<Database>(SUPABASE_URL, SUPABASE_PUBLISHABLE_KEY);
+export const supabase = createClient<Database>(SUPABASE_URL, SUPABASE_KEY);

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,22 +1,27 @@
-import { defineConfig } from "vite";
+import { defineConfig, loadEnv } from "vite";
 import react from "@vitejs/plugin-react-swc";
 import path from "path";
 import { componentTagger } from "lovable-tagger";
 
 // https://vitejs.dev/config/
-export default defineConfig(({ mode }) => ({
-  server: {
-    host: "::",
-    port: 8080,
-  },
-  plugins: [
-    react(),
-    mode === 'development' &&
-    componentTagger(),
-  ].filter(Boolean),
-  resolve: {
-    alias: {
-      "@": path.resolve(__dirname, "./src"),
+export default defineConfig(({ mode }) => {
+  const env = loadEnv(mode, process.cwd(), "");
+  process.env = { ...process.env, ...env };
+
+  return {
+    server: {
+      host: "::",
+      port: 8080,
     },
-  },
-}));
+    plugins: [
+      react(),
+      mode === 'development' &&
+      componentTagger(),
+    ].filter(Boolean),
+    resolve: {
+      alias: {
+        "@": path.resolve(__dirname, "./src"),
+      },
+    },
+  };
+});


### PR DESCRIPTION
## Summary
- load `.env` values in Vite config so environment variables are available
- read Supabase URL and anon key from `import.meta.env`
- document Supabase environment variables and provide `.env.example`
- ignore local `.env` files

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: 45 problems)
- `npx eslint vite.config.ts src/integrations/supabase/client.ts`

------
https://chatgpt.com/codex/tasks/task_e_689af9fb6054832b98538ea2528aa4c8